### PR TITLE
fix setblock

### DIFF
--- a/src/Lib/Data/Vanilla/setblock.ts
+++ b/src/Lib/Data/Vanilla/setblock.ts
@@ -24,4 +24,25 @@ export const setblock: CommandInfo[] = [
       },
     ],
   },
+  {
+    name: "setblock",
+    documentation: "Places the specified block.",
+    parameters: [
+      { text: "setblock", type: ParameterType.keyword, required: true },
+      { text: "position x", type: ParameterType.coordinate, required: true },
+      { text: "position y", type: ParameterType.coordinate, required: true },
+      { text: "position z", type: ParameterType.coordinate, required: true },
+      { text: "tile name", type: ParameterType.block, required: true },
+      {
+        text: "tile data",
+        type: ParameterType.integer,
+        required: false,
+      },
+      {
+        text: "old block mode",
+        type: ParameterType.oldBlockMode,
+        required: false,
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Following my other PR,
The 5th argument of the setblock command can also be an integer.

"tileData"

![image](https://github.com/Blockception/BC-Minecraft-Bedrock-Command/assets/73346827/70a7e6da-4689-4aac-b9b1-584b22f0eb8d)
