### PR TITLE
Correct inputpermission parameter type

### DIFF
--- a/src/Lib/Data/Vanilla/inputpermission.ts
+++ b/src/Lib/Data/Vanilla/inputpermission.ts
@@ -5,22 +5,22 @@ import { CommandInfo } from "../CommandInfo";
 export const inputpermission: CommandInfo[] = [
   {
     name: "inputpermission",
-    documentation: "Forces to open an NPC dialogue box to the targeted player(s)",
+    documentation: "Queries the status of an input permission",
     parameters: [
       { text: "inputpermission", type: ParameterType.keyword, required: true },
       { text: "query", type: ParameterType.keyword, required: true },
-      { text: "target", type: ParameterType.entity, required: true, options: { playerOnly: true } },
+      { text: "target", type: ParameterType.selector, required: true, options: { playerOnly: true } },
       { text: "permission", type: ParameterType.permission, required: true },
       { text: "state", type: ParameterType.permissionState, required: false },
     ],
   },
   {
     name: "inputpermission",
-    documentation: "Forces to open an NPC dialogue box to the targeted player(s)",
+    documentation: "Sets whether or not a player's input can affect their character",
     parameters: [
       { text: "inputpermission", type: ParameterType.keyword, required: true },
       { text: "set", type: ParameterType.keyword, required: true },
-      { text: "target", type: ParameterType.entity, required: true, options: { playerOnly: true } },
+      { text: "target", type: ParameterType.selector, required: true, options: { playerOnly: true } },
       { text: "permission", type: ParameterType.permission, required: true },
       { text: "state", type: ParameterType.permissionState, required: true },
     ],


### PR DESCRIPTION
`entity` (e.g. `minecraft:cow`) -> `selector` (e.g. `@p`)
Also fixes copy/pasted description from `dialogue` :)